### PR TITLE
Fix header problem and Windows compile issues

### DIFF
--- a/package-win-linux/setup.py
+++ b/package-win-linux/setup.py
@@ -5,14 +5,49 @@ import ebi
 
 origIsSystemDLL = py2exe.build_exe.isSystemDLL
 def isSystemDLL(pathname):
-        if os.path.basename(pathname).lower() in ("msvcp71.dll", "gdiplus.dll", "msvcp90.dll"): 
-                return 0
-        return origIsSystemDLL(pathname)
+    if os.path.basename(pathname).lower() in ("msvcp71.dll", "gdiplus.dll", "msvcp90.dll"): 
+        return 0
+    return origIsSystemDLL(pathname)
 py2exe.build_exe.isSystemDLL = isSystemDLL
 
-setup(name = "EQUELLA Bulk Importer (EBI)",
-      version = ebi.Version,      
-      windows=[{"script":"ebi.py","icon_resources":[(0x0004,"ebismall.ico")],"copyright":"Copyright (c) 2014 Pearson plc. All rights reserved."}],
-      description = "EQUELLA Bulk Importer for uploading content into the EQUELLA(R) content management system",
-      )
+setup(
+    name = "EQUELLA Bulk Importer (EBI)",
+    version = ebi.Version,      
+    windows=[{"script":"ebi.py","icon_resources":[(0x0004,"ebismall.ico")],"copyright":"Copyright (c) 2014 Pearson plc. All rights reserved."}],
+    options={
+        'py2exe': {
+            "dll_excludes": [
+                "MSVCP90.dll",
+                "api-ms-win-core-string-l1-1-0.dll",
+                "api-ms-win-core-string-obsolete-l1-1-0.dll",
+                "api-ms-win-core-com-l1-1-0.dll",
+                "api-ms-win-core-sysinfo-l1-1-0.dll",
+                "api-ms-win-core-debug-l1-1-0.dll",
+                "api-ms-win-core-profile-l1-1-0.dll",
+                "api-ms-win-core-synch-l1-2-0.dll",
+                "api-ms-win-core-synch-l1-1-0.dll",
+                "api-ms-win-core-errorhandling-l1-1-0.dll",
+                "api-ms-win-core-libraryloader-l1-2-0.dll",
+                "api-ms-win-core-delayload-l1-1-1.dll",
+                "api-ms-win-core-delayload-l1-1-0.dll",
+                "api-ms-win-core-processthreads-l1-1-0.dll",
+                "api-ms-win-core-processenvironment-l1-1-0.dll",
+                "api-ms-win-eventing-provider-l1-1-0.dll",
+                "api-ms-win-core-file-l1-1-0.dll",
+                "api-ms-win-core-memory-l1-1-0.dll",
+                "api-ms-win-core-threadpool-l1-2-0.dll",
+                "api-ms-win-core-localization-l1-2-0.dll",
+                "api-ms-win-core-handle-l1-1-0.dll",
+                "api-ms-win-core-kernel32-legacy-l1-1-0.dll",
+                "api-ms-win-core-heap-l1-1-0.dll",
+                "api-ms-win-core-heap-l2-1-0.dll",
+                "api-ms-win-core-heap-obsolete-l1-1-0.dll",
+                "api-ms-win-security-base-l1-1-0.dll",
+                "api-ms-win-core-libraryloader-l1-2-1.dll",
+                "api-ms-win-core-rtlsupport-l1-1-0.dll"
+            ]
+        }
+    },
+    description = "EQUELLA Bulk Importer for uploading content into the EQUELLA(R) content management system",
+)
 

--- a/source/equellaclient41.py
+++ b/source/equellaclient41.py
@@ -258,11 +258,21 @@ class TLEClient:
             responseInfo = response.info()
             headers = {}
             cookie = responseInfo.getheader('set-cookie')
+
+            added_cookie = []
+            for cookie_name in self._cookieJar:
+                name = cookie_name.upper().split("=")[0].strip()
+                if ";" in name:
+                    name = name.split(";")[1].strip()
+                added_cookie.append(name)
+
             if cookie is not None:
                 for cookie_part in cookie.split(','):
                     for cookie_name in cookie_part.split(','):
-                        if not cookie_name.upper().split("=")[0].strip() in ["PATH", "DOMAIN", "EXPIRES", "SECURE",
-                                                                             "HTTPONLY"]:
+                        name = cookie_name.upper().split("=")[0].strip()
+                        if ";" in name:
+                            name = name.split(";")[1].strip()
+                        if not name in ["PATH", "DOMAIN", "EXPIRES", "SECURE", "HTTPONLY"] and not name in added_cookie:
                             # save cookie
                             self._cookieJar.append(cookie_name)
 


### PR DESCRIPTION
equellaclient41.py - Fix an issue where header grows too long causing errors in some load balancers
setup.py - Exclude some dlls so that it can be compiled in MS Windows 11.