### PR TITLE
Change encoding method to fix newline character issue for file uploading

### DIFF
--- a/source/equellaclient41.py
+++ b/source/equellaclient41.py
@@ -853,8 +853,6 @@ class NewItemClient:
                         self.owner.echo(showstatus + " Uploading...Halted by user", False)
                     break
                 uploaded += len(chunk)
-                #encodedChunk = b2a_base64(chunk)
-                # Nelson: To fix '\n' issue in base64 encoding
                 encodedChunk = base64.b64encode(chunk)
 
                 self.parClient._uploadFile (self.stagingid, path, encodedChunk, firstChunk)

--- a/source/equellaclient41.py
+++ b/source/equellaclient41.py
@@ -34,6 +34,7 @@ from urlparse import urlparse
 import codecs
 import os, os.path, traceback, time
 from string import ascii_letters
+import base64
 import wx
 import ssl
 
@@ -852,7 +853,10 @@ class NewItemClient:
                         self.owner.echo(showstatus + " Uploading...Halted by user", False)
                     break
                 uploaded += len(chunk)
-                encodedChunk = b2a_base64(chunk)
+                #encodedChunk = b2a_base64(chunk)
+                # Nelson: To fix '\n' issue in base64 encoding
+                encodedChunk = base64.b64encode(chunk)
+
                 self.parClient._uploadFile (self.stagingid, path, encodedChunk, firstChunk)
 
                 if firstChunk == "true":


### PR DESCRIPTION
This is to fix an issue which is casued by Base64 encoding/decoding mechanism being changed on the server side.