### PR TITLE
fix: write() error with Save text XML

### DIFF
--- a/source/RowProcessor.py
+++ b/source/RowProcessor.py
@@ -1121,7 +1121,7 @@ class RowProcessor:
             xmlFilename = os.path.join(xmlFolderName, "ebi-%06d.xml" % row_counter)
 
             with open(xmlFilename, "w") as fp:
-                fp.write(item.newDom.toprettyxml("    ", "\n", self.encoding))
+                fp.write(item.newDom.toprettyxml("    ", "\n", self.encoding).decode(self.encoding))
 
         # cancel edit (test only)
         item.parClient._cancelEdit(item.getUUID(), item.getVersion())

--- a/source/RowProcessor.py
+++ b/source/RowProcessor.py
@@ -1120,7 +1120,7 @@ class RowProcessor:
 
             xmlFilename = os.path.join(xmlFolderName, "ebi-%06d.xml" % row_counter)
 
-            with open(xmlFilename, "w") as fp:
+            with open(xmlFilename, "w", encoding=self.encoding) as fp:
                 fp.write(item.newDom.toprettyxml("    ", "\n", self.encoding).decode(self.encoding))
 
         # cancel edit (test only)


### PR DESCRIPTION
I tried to perform a test run with EBI today using the "Save test XML" option but I received an error from each of my CSV rows:

```
10:53:44:  Row 1 [1 of 70]: Validating item...
  Attachment: S37.53.jpeg (506,978 bytes)
10:53:44: ERROR: write() argument must be str, not bytes
  DEBUG: rowErrorColumn is -1, error not stored
```

These are valid rows and without the XML file option tests succeed.

The cause is line 1124 of RowProcessor.py which writes bytes instead of a string. `open(f, 'w')` returns a `io.TextIOBase` whose `write()` method expects strings, not bytes, but the XML `Node.toprettyxml()` has an encoding parameter which causes it to return bytes. My patch decodes the string again before writing to the XML file. Alternatively, you could open the XML file in `wb` mode instead, but I think encoding/decoding might have some function in ensuring the encoding.